### PR TITLE
chore: change `license` and `private` keys in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "student-center",
-  "private": false,
+  "private": true,
+  "license": "UNLICENSED",
   "scripts": {
     "build": "next build",
     "dev": "next dev",


### PR DESCRIPTION
This pull request changes `license` and `private` keys in package.json file.

Since this project is not open source, the correct value for `license` key is `UNLICENSED`, according to [official documentation](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license).

To prevent accidental publication, `private` key should be set to `true`.