### PR TITLE
chore: add jsx-a11y and react specific eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,6 +43,26 @@
     "capitalized-comments": ["warn", "always"],
     "curly": "warn",
     "eqeqeq": "error",
+    "jsx-a11y/aria-role": "error",
+    "jsx-a11y/autocomplete-valid": [
+      "error",
+      {
+        "inputComponents": ["Button", "Input"]
+      }
+    ],
+    "jsx-a11y/heading-has-content": [
+      "error",
+      {
+        "components": ["Heading"]
+      }
+    ],
+    "jsx-a11y/iframe-has-title": "error",
+    "jsx-a11y/mouse-events-have-key-events": "error",
+    "jsx-a11y/no-access-key": "error",
+    "jsx-a11y/no-noninteractive-tabindex": "error",
+    "jsx-a11y/no-redundant-roles": "error",
+    "jsx-a11y/no-static-element-interactions": "error",
+    "jsx-a11y/tabindex-no-positive": "error",
     "multiline-comment-style": "warn",
     "no-confusing-arrow": "error",
     "no-else-return": "error",
@@ -67,6 +87,28 @@
     "prefer-numeric-literals": "error",
     "prefer-object-spread": "error",
     "prefer-template": "error",
+    "react/function-component-definition": [
+      "error",
+      {
+        "namedComponents": "arrow-function",
+        "unnamedComponents": "arrow-function"
+      }
+    ],
+    "react/jsx-boolean-value": "error",
+    "react/jsx-curly-brace-presence": ["error", "never"],
+    "react/jsx-fragments": ["error", "syntax"],
+    "react/jsx-no-useless-fragment": "error",
+    "react/jsx-sort-props": [
+      "warn",
+      {
+        "callbacksLast": false,
+        "ignoreCase": true,
+        "noSortAlphabetically": false,
+        "reservedFirst": false,
+        "shorthandFirst": false,
+        "shorthandLast": false
+      }
+    ],
     "quote-props": ["error", "as-needed"],
     "simple-import-sort/imports": [
       "warn",


### PR DESCRIPTION
This pull request adds new rules to ESLint configuration file from [jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) and [react](https://github.com/yannickcr/eslint-plugin-react) plugins.