### PR TITLE
feat: add `useTypeSafeTranslation` hook

### DIFF
--- a/src/hooks/useTypeSafeTranslation.ts
+++ b/src/hooks/useTypeSafeTranslation.ts
@@ -1,0 +1,23 @@
+import type { TranslationQuery } from "next-translate";
+import useTranslation from "next-translate/useTranslation";
+
+import type I18nKey from "@/types/i18n";
+
+export type TypeSafeI18n = {
+  lang: string;
+  t: TypeSafeTranslate;
+};
+
+export type TypeSafeTranslate = <T = string>(
+  i18nKey: I18nKey,
+  query?: TranslationQuery | null,
+  options?: {
+    default?: string;
+    fallback?: string[] | string;
+    returnObjects?: boolean;
+  }
+) => T;
+
+const useTypeSafeTranslation = (): TypeSafeI18n => useTranslation();
+
+export default useTypeSafeTranslation;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,11 @@
 import type { NextPage } from "next";
-import useTranslation from "next-translate/useTranslation";
+
+import useTypeSafeTranslation from "@/hooks/useTypeSafeTranslation";
 
 const Home: NextPage = () => {
-  const { t } = useTranslation("common");
+  const { t } = useTypeSafeTranslation();
 
-  return <div className="flex text-5xl">{t("homepage")}</div>;
+  return <div className="flex text-5xl">{t("common:homepage")}</div>;
 };
 
 export default Home;


### PR DESCRIPTION
This pull request adds `useTypeSafeTranslation` hook as a wrapper for [next-translate](https://github.com/vinissimus/next-translate)'s `useTranslation` to provide type safety while writing translation keys.

> **Note**: [Plurals](https://github.com/vinissimus/next-translate#5-plurals) may not work properly.