### PR TITLE
chore: update eslint-plugin-typescript-sort-keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
         "next": "12.0.2",
@@ -24,7 +25,7 @@
         "eslint-plugin-sort-destructure-keys": "^1.4.0",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
         "eslint-plugin-tailwindcss": "^1.17.0",
-        "eslint-plugin-typescript-sort-keys": "^2.0.0",
+        "eslint-plugin-typescript-sort-keys": "^2.1.0",
         "eslint-plugin-unused-imports": "^1.1.5",
         "postcss": "^8.3.11",
         "prettier": "^2.4.1",
@@ -3359,13 +3360,13 @@
       }
     },
     "node_modules/eslint-plugin-typescript-sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-2.0.0.tgz",
-      "integrity": "sha512-k1LhChmRO8A1waD1ggSABB5pc2u9qTRdL1R1nylU6ODYR5hFb4nQlB3bQyBSnLsINHZuvrkNfPyKnNV8RUBlqQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-2.1.0.tgz",
+      "integrity": "sha512-ET7ABypdz19m47QnKynzNfWPi4CTNQ5jQQC1X5d0gojIwblkbGiCa5IilsqzBTmqxZ0yXDqKBO/GBkBFQCOFsg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^5.0.0",
-        "json-schema": "^0.3.0",
+        "json-schema": "^0.4.0",
         "natural-compare-lite": "^1.4.0"
       },
       "engines": {
@@ -4658,9 +4659,9 @@
       "dev": true
     },
     "node_modules/json-schema": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
-      "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -9655,13 +9656,13 @@
       }
     },
     "eslint-plugin-typescript-sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-2.0.0.tgz",
-      "integrity": "sha512-k1LhChmRO8A1waD1ggSABB5pc2u9qTRdL1R1nylU6ODYR5hFb4nQlB3bQyBSnLsINHZuvrkNfPyKnNV8RUBlqQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-sort-keys/-/eslint-plugin-typescript-sort-keys-2.1.0.tgz",
+      "integrity": "sha512-ET7ABypdz19m47QnKynzNfWPi4CTNQ5jQQC1X5d0gojIwblkbGiCa5IilsqzBTmqxZ0yXDqKBO/GBkBFQCOFsg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^5.0.0",
-        "json-schema": "^0.3.0",
+        "json-schema": "^0.4.0",
         "natural-compare-lite": "^1.4.0"
       }
     },
@@ -10470,9 +10471,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz",
-      "integrity": "sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-sort-destructure-keys": "^1.4.0",
     "eslint-plugin-sort-keys-fix": "^1.1.2",
     "eslint-plugin-tailwindcss": "^1.17.0",
-    "eslint-plugin-typescript-sort-keys": "^2.0.0",
+    "eslint-plugin-typescript-sort-keys": "^2.1.0",
     "eslint-plugin-unused-imports": "^1.1.5",
     "postcss": "^8.3.11",
     "prettier": "^2.4.1",


### PR DESCRIPTION
This pull request fixes [CVE-2021-3918](https://github.com/advisories/GHSA-896r-f27r-55mw) vulnerability present in [json-schema](https://github.com/kriszyp/json-schema) dependency by updating [eslint-plugin-typescript-sort-keys](https://github.com/infctr/eslint-plugin-typescript-sort-keys) package to version 2.1.0.