### PR TITLE
style: remove unnecessary react imports

### DIFF
--- a/src/components/head.tsx
+++ b/src/components/head.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import NextHead from "next/head";
 
 import useTypeSafeTranslation from "@/hooks/useTypeSafeTranslation";

--- a/src/layouts/default.tsx
+++ b/src/layouts/default.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import Head, { HeadProps } from "@/components/head";
 
 export type LayoutDefaultProps = {


### PR DESCRIPTION
This pull request removes unnecessary React imports. Importing React is not required to use JSX since the introduction of React 17.