### PR TITLE
feat: add image and link components

### DIFF
--- a/src/components/image.tsx
+++ b/src/components/image.tsx
@@ -1,0 +1,7 @@
+import NextImage, { ImageProps as NextImageProps } from "next/image";
+
+export type ImageProps = NextImageProps;
+
+const Image = (props: ImageProps) => <NextImage {...props} />;
+
+export default Image;

--- a/src/components/link.tsx
+++ b/src/components/link.tsx
@@ -1,0 +1,49 @@
+import NextLink, { LinkProps as NextLinkProps } from "next/link";
+
+export type LinkProps = NextLinkProps &
+  Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof NextLinkProps> & {
+    children: React.ReactNode;
+    className?: string;
+  };
+
+const Link = ({
+  as,
+  children,
+  className,
+  href,
+  locale,
+  passHref = false,
+  prefetch,
+  replace,
+  scroll,
+  shallow,
+  ...props
+}: LinkProps) => {
+  if (
+    (typeof href === "string" && href.startsWith("/")) ||
+    typeof href === "object"
+  ) {
+    return (
+      <NextLink
+        as={as}
+        href={href}
+        locale={locale}
+        passHref={passHref}
+        prefetch={prefetch}
+        replace={replace}
+        scroll={scroll}
+        shallow={shallow}
+      >
+        {passHref ? children : <a className="">{children}</a>}
+      </NextLink>
+    );
+  }
+
+  return (
+    <a className={className} href={href} {...props}>
+      {children}
+    </a>
+  );
+};
+
+export default Link;


### PR DESCRIPTION
This pull request adds `Image` and `Link` components, implementing or extending the functionality of [`next/image`](https://nextjs.org/docs/api-reference/next/image) and [`next/link`](https://nextjs.org/docs/api-reference/next/link) respectively.