### PR TITLE
fix: replace empty `className` attribute with a prop

### DIFF
--- a/src/components/link.tsx
+++ b/src/components/link.tsx
@@ -34,7 +34,7 @@ const Link = ({
         scroll={scroll}
         shallow={shallow}
       >
-        {passHref ? children : <a className="">{children}</a>}
+        {passHref ? children : <a className={className}>{children}</a>}
       </NextLink>
     );
   }


### PR DESCRIPTION
This pull request fixes empty `className` attribute left out in #27 by replacing it with `className` prop. 