### PR TITLE
fix: pass `Link` props to anchor element

### DIFF
--- a/src/components/link.tsx
+++ b/src/components/link.tsx
@@ -34,7 +34,13 @@ const Link = ({
         scroll={scroll}
         shallow={shallow}
       >
-        {passHref ? children : <a className={className}>{children}</a>}
+        {passHref ? (
+          children
+        ) : (
+          <a className={className} {...props}>
+            {children}
+          </a>
+        )}
       </NextLink>
     );
   }


### PR DESCRIPTION
This pull request fixes `Link` component by passing `...props` into anchor element.