### PR TITLE
docs: update CONTRIBUTING code examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,12 +287,12 @@ All of the code is linted with [ESLint](https://eslint.org/) and formatted with 
   ```
 
   ```tsx
-  import useTranslation from "next-translate/useTranslation";
+  import useTypeSafeTranslation from "@/hooks/useTypeSafeTranslation";
 
   const Component = () => {
-    const { t } = useTranslation("common");
+    const { t } = useTypeSafeTranslation();
 
-    return <div>{t("hello-world")}</div>;
+    return <div>{t("common:hello-world")}</div>;
   };
 
   export default Component;


### PR DESCRIPTION
This pull request updates code examples in CONTRIBUTING file to use `@/hooks/useTypeSafeTranslation` hook instead of the [`next-translate/useTranslation`](https://github.com/vinissimus/next-translate#usetranslation) hook.