### PR TITLE
chore: change eslint configuration file format

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,31 +1,31 @@
-{
-  "extends": [
+module.exports = {
+  extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:tailwindcss/recommended",
     "next/core-web-vitals",
-    "prettier"
+    "prettier",
   ],
-  "parserOptions": {
-    "project": ["tsconfig.json"]
+  parserOptions: {
+    project: ["tsconfig.json"],
   },
-  "plugins": [
+  plugins: [
     "@typescript-eslint",
     "simple-import-sort",
     "sort-destructure-keys",
     "sort-keys-fix",
     "tailwindcss",
     "typescript-sort-keys",
-    "unused-imports"
+    "unused-imports",
   ],
-  "rules": {
+  rules: {
     "@typescript-eslint/array-type": "error",
     "@typescript-eslint/consistent-indexed-object-style": "error",
     "@typescript-eslint/method-signature-style": "error",
     "@typescript-eslint/no-confusing-void-expression": [
       "error",
-      { "ignoreArrowShorthand": true }
+      { ignoreArrowShorthand: true },
     ],
     "@typescript-eslint/no-dynamic-delete": "error",
     "@typescript-eslint/no-meaningless-void-operator": "error",
@@ -40,20 +40,20 @@
     "@typescript-eslint/promise-function-async": "error",
     "@typescript-eslint/sort-type-union-intersection-members": "error",
     "@typescript-eslint/strict-boolean-expressions": "error",
-    "curly": "warn",
-    "eqeqeq": "error",
+    curly: "warn",
+    eqeqeq: "error",
     "jsx-a11y/aria-role": "error",
     "jsx-a11y/autocomplete-valid": [
       "error",
       {
-        "inputComponents": ["Button", "Input"]
-      }
+        inputComponents: ["Button", "Input"],
+      },
     ],
     "jsx-a11y/heading-has-content": [
       "error",
       {
-        "components": ["Heading"]
-      }
+        components: ["Heading"],
+      },
     ],
     "jsx-a11y/iframe-has-title": "error",
     "jsx-a11y/mouse-events-have-key-events": "error",
@@ -71,7 +71,7 @@
     "no-lonely-if": "warn",
     "no-regex-spaces": "error",
     "no-undef-init": "warn",
-    "no-unneeded-ternary": ["error", { "defaultAssignment": false }],
+    "no-unneeded-ternary": ["error", { defaultAssignment: false }],
     "no-unused-vars": "off",
     "no-useless-computed-key": "error",
     "no-useless-rename": "error",
@@ -89,9 +89,9 @@
     "react/function-component-definition": [
       "error",
       {
-        "namedComponents": "arrow-function",
-        "unnamedComponents": "arrow-function"
-      }
+        namedComponents: "arrow-function",
+        unnamedComponents: "arrow-function",
+      },
     ],
     "react/jsx-boolean-value": "error",
     "react/jsx-curly-brace-presence": ["error", "never"],
@@ -100,21 +100,21 @@
     "react/jsx-sort-props": [
       "warn",
       {
-        "callbacksLast": false,
-        "ignoreCase": true,
-        "noSortAlphabetically": false,
-        "reservedFirst": false,
-        "shorthandFirst": false,
-        "shorthandLast": false
-      }
+        callbacksLast: false,
+        ignoreCase: true,
+        noSortAlphabetically: false,
+        reservedFirst: false,
+        shorthandFirst: false,
+        shorthandLast: false,
+      },
     ],
     "quote-props": ["error", "as-needed"],
     "simple-import-sort/imports": [
       "warn",
       {
-        "groups": [
+        groups: [
           [
-            "^(assert|buffer|child_process|cluster|console|constants|crypto|dgram|dns|domain|events|fs|http|https|module|net|os|path|punycode|querystring|readline|repl|stream|string_decoder|sys|timers|tls|tty|url|util|vm|zlib|freelist|v8|process|async_hooks|http2|perf_hooks)(/.*|$)"
+            "^(assert|buffer|child_process|cluster|console|constants|crypto|dgram|dns|domain|events|fs|http|https|module|net|os|path|punycode|querystring|readline|repl|stream|string_decoder|sys|timers|tls|tty|url|util|vm|zlib|freelist|v8|process|async_hooks|http2|perf_hooks)(/.*|$)",
           ],
           ["^react"],
           ["^next"],
@@ -130,16 +130,16 @@
           ["^\\u0000"],
           ["^\\.\\.(?!/?$)", "^\\.\\./?$"],
           ["^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"],
-          ["^.+\\.s?css$"]
-        ]
-      }
+          ["^.+\\.s?css$"],
+        ],
+      },
     ],
     "simple-import-sort/exports": "warn",
     "sort-destructure-keys/sort-destructure-keys": "warn",
     "sort-keys-fix/sort-keys-fix": [
       "warn",
       "asc",
-      { "caseSensitive": false, "natural": true }
+      { caseSensitive: false, natural: true },
     ],
     "sort-vars": "warn",
     "spaced-comment": ["warn", "always"],
@@ -149,12 +149,12 @@
     "unused-imports/no-unused-vars": [
       "error",
       {
-        "args": "after-used",
-        "argsIgnorePattern": "^_",
-        "vars": "all",
-        "varsIgnorePattern": "^_"
-      }
+        args: "after-used",
+        argsIgnorePattern: "^_",
+        vars: "all",
+        varsIgnorePattern: "^_",
+      },
     ],
-    "yoda": "error"
-  }
-}
+    yoda: "error",
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "studentre",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {


### PR DESCRIPTION
This pull request changes ESLint's configuration file format from `.json` to `.js` for easier integration with JavaScript based tools.