### PR TITLE
refactor: revamp tailwind theme

### DIFF
--- a/src/components/logotype.tsx
+++ b/src/components/logotype.tsx
@@ -7,7 +7,7 @@ const Logotype = ({ className = "", ...props }: LogotypeProps) => {
 
   return (
     <span
-      className={`font-medium font-logo select-none text-transparent bg-clip-text bg-gradient-to-r from-logo-900 via-logo-700 to-logo-500 ${className}`}
+      className={`font-medium font-logo select-none text-transparent bg-clip-text bg-gradient-to-r from-brand-800 via-brand-600 to-brand-400 ${className}`}
       {...props}
     >
       {t("common:app-name")}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,14 @@
-const { lightBlue, ...colors } = require("tailwindcss/colors");
+const {
+  amber,
+  black,
+  coolGray,
+  green,
+  red,
+  sky,
+  white,
+} = require("tailwindcss/colors");
+
+const defaultTheme = require("tailwindcss/defaultTheme");
 
 module.exports = {
   darkMode: "class",
@@ -11,62 +21,35 @@ module.exports = {
     "./src/pages/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {
-      colors: {
-        ...colors,
-        error: {
-          dark: colors.red[700],
-          DEFAULT: colors.red[600],
-          light: colors.red[500],
-        },
-        info: {
-          dark: colors.sky[600],
-          DEFAULT: colors.sky[500],
-          light: colors.sky[400],
-        },
-        logo: {
-          500: "#42a5f5",
-          600: "#2196f3",
-          650: "#1e88e5",
-          700: "#1976d2",
-          800: "#1565c0",
-          900: "#0d47a1",
-        },
-        primary: colors.blue,
-        success: {
-          dark: colors.green[600],
-          DEFAULT: colors.green[500],
-          light: colors.green[400],
-        },
-        warning: {
-          dark: colors.amber[600],
-          DEFAULT: colors.amber[500],
-          light: colors.amber[400],
-        },
+    colors: {
+      black,
+      brand: {
+        50: "#f2f8ff",
+        100: "#e6f1ff",
+        200: "#bfddff",
+        300: "#99c9ff",
+        400: "#4da0ff",
+        500: "#0077ff",
+        600: "#006be6",
+        700: "#0059bf",
+        800: "#004799",
+        900: "#003a7d",
       },
+      current: "currentColor",
+      error: red,
+      gray: coolGray,
+      info: sky,
+      success: green,
+      transparent: "transparent",
+      warning: amber,
+      white,
+    },
+    extend: {
       fontFamily: {
+        ...defaultTheme.fontFamily,
         logo: ["outfit", "sans"],
         outfit: ["outfit"],
-        sans: [
-          "ui-sans-serif",
-          "system-ui",
-          "-apple-system",
-          "BlinkMacSystemFont",
-          "Segoe UI",
-          "Roboto",
-          "Helvetica Neue",
-          "Arial",
-          "Noto Sans",
-          "sans-serif",
-          "Apple Color Emoji",
-          "Segoe UI Emoji",
-          "Segoe UI Symbol",
-          "Noto Color Emoji",
-        ],
       },
     },
-  },
-  variants: {
-    extend: {},
   },
 };


### PR DESCRIPTION
This pull request revamps tailwind theme by:

- replacing `logo` and `primary` palettes with `brand` palette,
- assigning whole color groups to `error`, `info`, `success` and `warning` keys,
- overriding default color theme instead of extending it,
- extending font family to allow use of `mono` and `serif` fonts.