### PR TITLE
docs: fix incorrect logo source in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <p align="center">
-  <img alt="Studentre" src="https://raw.githubusercontent.com/skni-kod/StudentreFrontend/main/public/images/logo.svg" style="width: 50%" />
+  <img alt="Studentre" src="https://raw.githubusercontent.com/skni-kod/StudentreFrontend/main/public/images/logomark.svg" style="width: 8%" />
+  <br /><br />
+  <img alt="Studentre" src="https://raw.githubusercontent.com/skni-kod/StudentreFrontend/main/public/images/logotype.svg" style="width: 24%" />
 </p>
 <br />
 <p align="center">


### PR DESCRIPTION
This pull request fixes incorrect `src` attribute of `<img>` tag inside of README file.