### PR TITLE
feat: add `useTypeSafeTheme` hook

### DIFF
--- a/src/hooks/useTypeSafeTheme.ts
+++ b/src/hooks/useTypeSafeTheme.ts
@@ -1,0 +1,22 @@
+import { useTheme } from "next-themes";
+
+import type Theme from "@/types/theme";
+
+export type UseTypeSafeThemeProps = {
+  /** Forced theme name for the current page */
+  forcedTheme?: Theme;
+  /** If `enableSystem` is true and the active theme is "system", this returns whether the system preference resolved to "dark" or "light". Otherwise, identical to `theme` */
+  resolvedTheme?: Theme;
+  /** Update the theme */
+  setTheme: (theme: Theme) => void;
+  /** If enableSystem is true, returns the System theme preference ("dark" or "light"), regardless what the active theme is */
+  systemTheme?: Omit<Theme, "system">;
+  /** Active theme name */
+  theme?: Theme;
+  /** List of all available theme names */
+  themes: Theme[];
+};
+
+const useTypeSafeTheme = useTheme as () => UseTypeSafeThemeProps;
+
+export default useTypeSafeTheme;

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -1,0 +1,3 @@
+type Theme = "dark" | "light" | "system";
+
+export default Theme;


### PR DESCRIPTION
This pull request adds `useTypeSafeTheme` hook as a wrapper for [next-theme]'s `useTheme` to provide type safety while using themes.