### PR TITLE
fix: remove unnecessary named `export` of `I18nKey` type

### DIFF
--- a/scripts/i18n.ts
+++ b/scripts/i18n.ts
@@ -53,7 +53,7 @@ if (!keys.length) {
 const outputString = `${keys.reduce(
   (previous, current, index) =>
     `${previous}${index === 0 ? "" : " | "}"${current}"`,
-  "export type I18nKey = "
+  "type I18nKey = "
 )}\n\nexport default I18nKey`;
 
 const outputFile: string = prettier.format(outputString, {


### PR DESCRIPTION
This pull request removes unnecessary named `export` of `I18nKey` type, generated by `i18n.ts` script.