### PR TITLE
refactor: remove `TypeSafe` from hook names

### DIFF
--- a/src/components/head.tsx
+++ b/src/components/head.tsx
@@ -1,6 +1,6 @@
 import NextHead from "next/head";
 
-import useTypeSafeTranslation from "@/hooks/useTypeSafeTranslation";
+import useTranslation from "@/hooks/useTranslation";
 
 export type HeadProps = {
   children?: React.ReactNode;
@@ -9,7 +9,7 @@ export type HeadProps = {
 };
 
 const Head = ({ children, description, title }: HeadProps) => {
-  const { t } = useTypeSafeTranslation();
+  const { t } = useTranslation();
 
   return (
     <NextHead>

--- a/src/components/logomark.tsx
+++ b/src/components/logomark.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx";
 
 import Image, { ImageProps } from "@/components/image";
 
-import useTypeSafeTranslation from "@/hooks/useTypeSafeTranslation";
+import useTranslation from "@/hooks/useTranslation";
 
 import logomarkImage from "@/public/images/logomark.svg";
 
@@ -11,7 +11,7 @@ export type LogomarkProps = React.HTMLAttributes<HTMLElement> & {
 };
 
 const Logomark = ({ className = "", imageProps, ...props }: LogomarkProps) => {
-  const { t } = useTypeSafeTranslation();
+  const { t } = useTranslation();
 
   return (
     <figure className={clsx("relative", className)} {...props}>

--- a/src/components/logotype.tsx
+++ b/src/components/logotype.tsx
@@ -1,11 +1,11 @@
 import clsx from "clsx";
 
-import useTypeSafeTranslation from "@/hooks/useTypeSafeTranslation";
+import useTranslation from "@/hooks/useTranslation";
 
 export type LogotypeProps = React.HTMLAttributes<HTMLSpanElement>;
 
 const Logotype = ({ className = "", ...props }: LogotypeProps) => {
-  const { t } = useTypeSafeTranslation();
+  const { t } = useTranslation();
 
   return (
     <span

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,8 +1,8 @@
-import { useTheme } from "next-themes";
+import { useTheme as useNextThemesTheme } from "next-themes";
 
 import type Theme from "@/types/theme";
 
-export type UseTypeSafeThemeProps = {
+export type UseThemeProps = {
   /** Forced theme name for the current page */
   forcedTheme?: Theme;
   /** If `enableSystem` is true and the active theme is "system", this returns whether the system preference resolved to "dark" or "light". Otherwise, identical to `theme` */
@@ -17,6 +17,6 @@ export type UseTypeSafeThemeProps = {
   themes: Theme[];
 };
 
-const useTypeSafeTheme = useTheme as () => UseTypeSafeThemeProps;
+const useTheme = useNextThemesTheme as () => UseThemeProps;
 
-export default useTypeSafeTheme;
+export default useTheme;

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -1,14 +1,14 @@
 import type { TranslationQuery } from "next-translate";
-import useTranslation from "next-translate/useTranslation";
+import useNextTranslateTranslation from "next-translate/useTranslation";
 
 import type I18nKey from "@/types/i18n";
 
-export type TypeSafeI18n = {
+export type I18n = {
   lang: string;
-  t: TypeSafeTranslate;
+  t: Translate;
 };
 
-export type TypeSafeTranslate = <T = string>(
+export type Translate = <T = string>(
   i18nKey: I18nKey,
   query?: TranslationQuery | null,
   options?: {
@@ -18,6 +18,6 @@ export type TypeSafeTranslate = <T = string>(
   }
 ) => T;
 
-const useTypeSafeTranslation = (): TypeSafeI18n => useTranslation();
+const useTranslation = (): I18n => useNextTranslateTranslation();
 
-export default useTypeSafeTranslation;
+export default useTranslation;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,12 +3,12 @@ import type { NextPage } from "next";
 import Logomark from "@/components/logomark";
 import Logotype from "@/components/logotype";
 
-import useTypeSafeTranslation from "@/hooks/useTypeSafeTranslation";
+import useTranslation from "@/hooks/useTranslation";
 
 import LayoutDefault from "@/layouts/default";
 
 const Home: NextPage = () => {
-  const { t } = useTypeSafeTranslation();
+  const { t } = useTranslation();
 
   return (
     <LayoutDefault


### PR DESCRIPTION
This pull request removes `TypeSafe` from `useTypeSafeTheme` and `useTypeSafeTranslation` hook names.