### PR TITLE
feat: add `EASE` constant

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -118,6 +118,7 @@ module.exports = {
           ["^next"],
           ["^@?\\w"],
           ["^(@/components)(/.*|$)"],
+          ["^(@/constants)(/.*|$)"],
           ["^(@/hooks)(/.*|$)"],
           ["^(@/layouts)(/.*|$)"],
           ["^(@/locales)(/.*|$)"],

--- a/src/constants/animation/ease.ts
+++ b/src/constants/animation/ease.ts
@@ -1,0 +1,13 @@
+import type { Easing } from "framer-motion/types/types";
+
+import withInferredKeys from "@/utilities/with-inferred-keys";
+
+const asEase = withInferredKeys<Easing>();
+
+const EASE = asEase({
+  in: [0.4, 0, 1, 1],
+  inOut: [0.4, 0, 0.2, 1],
+  out: [0, 0, 0.2, 1],
+});
+
+export default EASE;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "noEmit": true,
     "paths": {
       "@/components/*": ["src/components/*"],
+      "@/constants/*": ["src/constants/*"],
       "@/hooks/*": ["src/hooks/*"],
       "@/layouts/*": ["src/layouts/*"],
       "@/locales/*": ["src/locales/*"],


### PR DESCRIPTION
This pull request adds `EASE` constant that stores values of [Tailwind CSS' transition timing function utilites](https://tailwindcss.com/docs/transition-timing-function) for further use with [Framer Motion's `ease` property](https://www.framer.com/docs/transition/###ease).