### PR TITLE
feat: add `plain` prop to `Logomark` component

### DIFF
--- a/src/components/logomark.tsx
+++ b/src/components/logomark.tsx
@@ -8,12 +8,29 @@ import logomarkImage from "@/public/images/logomark.svg";
 
 export type LogomarkProps = React.HTMLAttributes<HTMLElement> & {
   imageProps?: Omit<ImageProps, "alt" | "layout" | "objectFit" | "src">;
+  plain?: boolean;
 };
 
-const Logomark = ({ className = "", imageProps, ...props }: LogomarkProps) => {
+const Logomark = ({
+  className = "",
+  imageProps,
+  plain = false,
+  ...props
+}: LogomarkProps) => {
   const { t } = useTranslation();
 
-  return (
+  return plain ? (
+    <svg
+      className={className}
+      viewBox="0 0 12 26.957"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M45.355-.002 0 26.373V49.133l25.787 14.994L0 79.123V101.883l45.355-26.375V52.748L19.568 37.752l25.787-14.994V-.002z"
+        transform="matrix(.26459 0 0 .26459 0 0)"
+      />
+    </svg>
+  ) : (
     <figure className={clsx("relative", className)} {...props}>
       <Image
         alt={`${t("common:app-name")} - ${t("common:logo")}`}


### PR DESCRIPTION
This pull request adds `plain` prop to `Logomark` component that makes use of plain SVG version of the logo.