### PR TITLE
fix: type validity build error

### DIFF
--- a/src/modules/i18n/index.ts
+++ b/src/modules/i18n/index.ts
@@ -4,4 +4,5 @@ import type I18nKey from "./types/i18n-key";
 import type Translate from "./types/translate";
 import type UseTranslation from "./types/use-translation";
 
-export { I18n, I18nKey, Translate, UseTranslation, useTranslation };
+export type { I18n, I18nKey, Translate, UseTranslation };
+export { useTranslation };

--- a/src/modules/theme/index.ts
+++ b/src/modules/theme/index.ts
@@ -3,4 +3,5 @@ import type Theme from "./types/theme";
 import type UseTheme from "./types/use-theme";
 import type UseThemeProps from "./types/use-theme-props";
 
-export { Theme, UseTheme, useTheme, UseThemeProps };
+export type { Theme, UseTheme, UseThemeProps };
+export { useTheme };


### PR DESCRIPTION
This pull request fixes type validity build error caused by re-exporting types using `export` instead of `export type` when the `--isolatedModules` flag requires the latter.