### PR TITLE
chore: add absolute paths support for script files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "prettier": "^2.4.1",
         "tailwindcss": "^3.0.7",
         "ts-node": "^10.4.0",
+        "tsconfig-paths": "^3.12.0",
         "typescript": "4.4.4"
       }
     },
@@ -10126,9 +10127,9 @@
       "dev": true
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
-      "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
@@ -17986,9 +17987,9 @@
       }
     },
     "tsconfig-paths": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
-      "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "dev": "next dev",
     "fix": "next lint --fix",
-    "i18n": "ts-node --project scripts/tsconfig.json scripts/i18n/index.ts",
+    "i18n": "ts-node -r tsconfig-paths/register --project ./scripts/tsconfig.json ./scripts/i18n/index.ts",
     "lint": "next lint",
     "postinstall": "npm run i18n",
     "start": "next start",
@@ -45,6 +45,7 @@
     "prettier": "^2.4.1",
     "tailwindcss": "^3.0.7",
     "ts-node": "^10.4.0",
+    "tsconfig-paths": "^3.12.0",
     "typescript": "4.4.4"
   }
 }

--- a/scripts/i18n/generate-i18n-key-file.ts
+++ b/scripts/i18n/generate-i18n-key-file.ts
@@ -3,9 +3,10 @@ import path from "path";
 
 import prettier, { Options } from "prettier";
 
+import getDeepKeys from "@/utilities/deep-keys";
+import log from "@/utilities/log";
+
 import prettierConfig from "../../.prettierrc.js";
-import getDeepKeys from "../../src/utilities/deep-keys";
-import log from "../../src/utilities/log";
 
 export class GenerateI18nKeyError extends Error {
   readonly code: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,18 +12,9 @@
     "moduleResolution": "node",
     "noEmit": true,
     "paths": {
-      "@/components/*": ["src/components/*"],
-      "@/constants/*": ["src/constants/*"],
-      "@/hooks/*": ["src/hooks/*"],
-      "@/layouts/*": ["src/layouts/*"],
-      "@/locales/*": ["src/locales/*"],
-      "@/modules/*": ["src/modules/*"],
-      "@/pages/*": ["src/pages/*"],
-      "@/public/*": ["public/*"],
-      "@/scripts/*": ["scripts/*"],
-      "@/styles/*": ["src/styles/*"],
-      "@/types/*": ["src/types/*"],
-      "@/utilities/*": ["src/utilities/*"]
+      "@/*": ["./src/*"],
+      "@/public/*": ["./public/*"],
+      "@/scripts/*": ["./scripts/*"]
     },
     "resolveJsonModule": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This pull request adds absolute paths support for script files executed with [ts-node](https://github.com/TypeStrong/ts-node) by the use of [tsconfig-paths](https://github.com/dividab/tsconfig-paths).