### PR TITLE
fix: stop tracking i18n `index.ts` file

### DIFF
--- a/src/modules/i18n/index.ts
+++ b/src/modules/i18n/index.ts
@@ -1,8 +1,0 @@
-import useTranslation from "./hooks/use-translation";
-import type I18n from "./types/i18n";
-import type I18nKey from "./types/i18n-key";
-import type Translate from "./types/translate";
-import type UseTranslation from "./types/use-translation";
-
-export type { I18n, I18nKey, Translate, UseTranslation };
-export { useTranslation };


### PR DESCRIPTION
This pull request removes tracking of `/src/modules/i18n/index.ts` file.