### PR TITLE
chore: fix eslint import sort groups

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,7 +121,7 @@ module.exports = {
           ["^next"],
           ["^@?\\w"],
           ["^(@/components)(/.*|$)"],
-          ["^(@/config)(/.*|$)"],
+          ["^(@/configuration)(/.*|$)"],
           ["^(@/hooks)(/.*|$)"],
           ["^(@/locales)(/.*|$)"],
           ["^(@/modules)(/.*|$)"],


### PR DESCRIPTION
This pull request fixes eslint import sort groups configuration.