### PR TITLE
fix: add missing `StaticImageData` type import

### DIFF
--- a/src/components/logomark.tsx
+++ b/src/components/logomark.tsx
@@ -1,5 +1,7 @@
 import type { HTMLAttributes } from "react";
 
+import type { StaticImageData } from "next/image";
+
 import clsx from "clsx";
 
 import { Image, ImageProps } from "@/components/image";


### PR DESCRIPTION
This pull request fixes missing `StaticImageData` type import inside of `Logomark` component.